### PR TITLE
Support using aliases in GROUP BY clause

### DIFF
--- a/lib/logsql/select.go
+++ b/lib/logsql/select.go
@@ -963,6 +963,10 @@ func (v *selectTranslatorVisitor) buildStatsPipe(stmt *ast.SelectStatement) ([]s
 				return nil, false, err
 			}
 			if _, ok := groupLookup[field]; !ok {
+				alias := strings.TrimSpace(col.Alias)
+				if alias != "" {
+					field += fmt.Sprintf(" (with alias: %s)", formatFieldName(alias))
+				}
 				return nil, false, &TranslationError{
 					Code:    http.StatusBadRequest,
 					Message: fmt.Sprintf("translator: column %s must appear in GROUP BY", field),
@@ -992,6 +996,10 @@ func (v *selectTranslatorVisitor) buildStatsPipe(stmt *ast.SelectStatement) ([]s
 					if renderErr != nil {
 						rendered = fmt.Sprintf("%T", expr)
 					}
+					alias := strings.TrimSpace(col.Alias)
+					if alias != "" {
+						rendered += fmt.Sprintf(" (with alias: %s)", formatFieldName(alias))
+					}
 					return nil, false, &TranslationError{
 						Code:    http.StatusBadRequest,
 						Message: fmt.Sprintf("translator: non-aggregate function %s must appear in GROUP BY", rendered),
@@ -1006,6 +1014,10 @@ func (v *selectTranslatorVisitor) buildStatsPipe(stmt *ast.SelectStatement) ([]s
 					rendered, renderErr := render.Render(expr)
 					if renderErr != nil {
 						rendered = fmt.Sprintf("%T", expr)
+					}
+					alias := strings.TrimSpace(col.Alias)
+					if alias != "" {
+						rendered += fmt.Sprintf(" (with alias: %s)", formatFieldName(alias))
 					}
 					return nil, false, &TranslationError{
 						Code:    http.StatusBadRequest,

--- a/lib/logsql/select.go
+++ b/lib/logsql/select.go
@@ -904,11 +904,13 @@ func (v *selectTranslatorVisitor) buildStatsPipe(stmt *ast.SelectStatement) ([]s
 	groupFields := make([]string, 0)
 	groupLookup := make(map[string]struct{})
 	preGroupPipes := make([]string, 0)
+	aliasSources := v.collectGroupAliases(stmt.Columns)
 
 	if hasGroup {
 		v.groupExprAliases = make(map[string]string)
 		for i, expr := range stmt.GroupBy {
-			exprKey, err := render.Render(expr)
+			resolvedExpr := v.resolveGroupByAlias(expr, aliasSources)
+			exprKey, err := render.Render(resolvedExpr)
 			if err != nil {
 				return nil, false, &TranslationError{
 					Code:    http.StatusBadRequest,
@@ -921,7 +923,7 @@ func (v *selectTranslatorVisitor) buildStatsPipe(stmt *ast.SelectStatement) ([]s
 				groupLookup[existing] = struct{}{}
 				continue
 			}
-			fieldName, pipes, err := v.prepareGroupByField(expr, i)
+			fieldName, pipes, err := v.prepareGroupByField(resolvedExpr, i)
 			if err != nil {
 				return nil, false, err
 			}
@@ -1093,6 +1095,60 @@ func (v *selectTranslatorVisitor) prepareGroupByField(expr ast.Expr, index int) 
 			Message: fmt.Sprintf("translator: unsupported GROUP BY expression %T", expr),
 		}
 	}
+}
+
+func (v *selectTranslatorVisitor) collectGroupAliases(columns []ast.SelectItem) map[string]ast.Expr {
+	if len(columns) == 0 {
+		return nil
+	}
+	aliases := make(map[string]ast.Expr)
+	for _, col := range columns {
+		alias := strings.TrimSpace(col.Alias)
+		if alias == "" {
+			continue
+		}
+		if _, ok := col.Expr.(*ast.StarExpr); ok {
+			continue
+		}
+		lower := strings.ToLower(alias)
+		if _, exists := aliases[lower]; !exists {
+			aliases[lower] = col.Expr
+		}
+		formatted := formatFieldName(alias)
+		formattedLower := strings.ToLower(formatted)
+		if _, exists := aliases[formattedLower]; !exists {
+			aliases[formattedLower] = col.Expr
+		}
+		if strings.HasPrefix(formatted, "\"") && strings.HasSuffix(formatted, "\"") && len(formatted) >= 2 {
+			unquoted := formatted[1 : len(formatted)-1]
+			unquotedLower := strings.ToLower(unquoted)
+			if _, exists := aliases[unquotedLower]; !exists {
+				aliases[unquotedLower] = col.Expr
+			}
+		}
+	}
+	if len(aliases) == 0 {
+		return nil
+	}
+	return aliases
+}
+
+func (v *selectTranslatorVisitor) resolveGroupByAlias(expr ast.Expr, aliases map[string]ast.Expr) ast.Expr {
+	if len(aliases) == 0 {
+		return expr
+	}
+	ident, ok := expr.(*ast.Identifier)
+	if !ok {
+		return expr
+	}
+	if len(ident.Parts) != 1 {
+		return expr
+	}
+	key := strings.ToLower(ident.Parts[0])
+	if replacement, ok := aliases[key]; ok {
+		return replacement
+	}
+	return expr
 }
 
 func (v *selectTranslatorVisitor) lookupGroupExpr(expr ast.Expr) (string, bool, error) {

--- a/lib/logsql/select_test.go
+++ b/lib/logsql/select_test.go
@@ -315,6 +315,16 @@ SELECT user FROM recent_errors WHERE service = 'api'`,
 			expected: "* | format \"<lc:user>\" as group_1 | stats by (group_1) count() total | rename group_1 as user_lower",
 		},
 		{
+			name:     "group by select alias",
+			sql:      "SELECT user AS usr, COUNT(*) AS total FROM logs GROUP BY usr",
+			expected: "* | stats by (user) count() total | rename user as usr",
+		},
+		{
+			name:     "group by function alias",
+			sql:      "SELECT LOWER(user) AS user_lower, COUNT(*) AS total FROM logs GROUP BY user_lower",
+			expected: "* | format \"<lc:user>\" as group_1 | stats by (group_1) count() total | rename group_1 as user_lower",
+		},
+		{
 			name: "join with subquery",
 			sql: `SELECT l.user, m.fail_count
 FROM logs AS l


### PR DESCRIPTION
and extend with alias error message about fields that must be listed in GROUP BY clause.

Before change:

<img width="950" height="385" alt="image" src="https://github.com/user-attachments/assets/54b71470-6c46-4680-9c0d-bb66b02e79b7" />

After change:

<img width="950" height="389" alt="image" src="https://github.com/user-attachments/assets/8d2a2b72-d652-413a-ace2-a0506e9b6409" />

And new error message with alias:

<img width="951" height="391" alt="image" src="https://github.com/user-attachments/assets/4e6cd3d1-cd8d-4618-8a13-81f836bc50db" />
