### PR TITLE
.github: set 21-days cooldown for github action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 21
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
Set a 21 day cooldown for actions dependabot updates.